### PR TITLE
Use latest version and cleaning go.sum

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY . .
 
 # Go get dependencies
 RUN go mod download
-
+RUN go mod tidy
 # # Build
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -a -o keptn-server main.go
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/bacherfl/argo-keptn-plugin
 go 1.22.0
 
 require (
-	github.com/argoproj/argo-workflows/v3 v3.5.5
+	github.com/argoproj/argo-workflows/v3 v3.5.11
 	github.com/google/uuid v1.4.0
 	github.com/gorilla/mux v1.8.1
 	k8s.io/apimachinery v0.24.3


### PR DESCRIPTION
the keptn executor plugin was generating an error due to incompatible libraries.